### PR TITLE
fix: division by zero error when GET products

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -61,9 +61,9 @@ class Product(SafeDeleteModel):
         total_rating = 0
         for rating in ratings:
             total_rating += rating.rating
-
-        avg = total_rating / len(ratings)
-        return avg
+        if len(ratings) > 0:
+            avg = total_rating / len(ratings)
+            return avg
 
     class Meta:
         verbose_name = ("product")


### PR DESCRIPTION
Description of PR that completes issue here...
Fixed the error that was given when the GET request for products was given. Added an if statement so the issue of division by zero wouldn't happen

## Changes

- added if statement to bangazonapi/models/product.py

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products` Gets all product

**Response**

HTTP/1.1" 200 ok

```json
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": null
    }
```

## Testing

- [ ] Open Postman
- [ ] Open the Products folder
- [ ] Select the GET all products tab
- [ ] Run Get request


## Related Issues

- Fixes #26 