### PR TITLE
fix: line_item is no longer duplicating in cart

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -82,7 +82,8 @@ class Profile(ViewSet):
         """
         try:
             current_user = Customer.objects.get(user=4)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user)
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={'request': request})
@@ -184,7 +185,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- got rid of the duplicate line_item in the cart in bangazonapi/views/profile
- deleted line 187

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/profile/cart` Gets users cart


**Response**

HTTP/1.1 200 OK

```json
{
    "id": 11,
    "url": "http://localhost:8000/orders/11",
    "created_date": "2021-06-02",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 10,
            "product": {
                "id": 88,
                "name": "Element",
                "price": 1727.41,
                "number_sold": 0,
                "description": "2003 Honda",
                "quantity": 3,
                "created_date": "2019-05-28",
                "location": "Dukoh",
                "image_path": null,
                "average_rating": null
            }
        }
    ],
    "size": 1
}
```

## Testing

Description of how to test code...

- [ ] Test GET shopping cart in Postman


## Related Issues

- Fixes #35 