### PR TITLE
fix: user profile now returns current_user

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,7 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(
                 recommender=current_user)
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed code on line 84 in bangazonapi/views/profile.py to get request.auth.user

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/profile ` Gets current logged in users profile

HTTP/1.1 200 OK

```json
{
    "id": 4,
    "url": "http://localhost:8000/customers/4",
    "user": {
        "first_name": "Steve",
        "last_name": "Brownlee",
        "email": "steve@stevebrownlee.com"
    },
    "phone_number": "555-1212",
    "address": "100 Infinity Way",
    "payment_types": [],
    "recommends": []
}
```

## Testing

Description of how to test code...

- [ ] Run Postmand
- [ ] Get request for profile

## Related Issues

- Fixes #33 